### PR TITLE
VS 2017 Preview image

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 os: Visual Studio 2017
 
 environment:
-  image: Visual Studio 2017
+  image: Visual Studio 2017 Preview
   SignClientSecret:
     secure: 2QKIbnEaxM/df01+GLvTjVKdLL7RlwKmCR/APcWFRUUF2VQWBRQFQ1DP3gK49epL
 


### PR DESCRIPTION
For net standard 2.0 builds, you have to use the preview image on appveyor. Until they update the normal image.