### PR TITLE
VS 2017 Preview image

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,5 @@ The data for schema validation is contained in static binary files that are not 
 - `dotnet run`
 
 This will go through and update schema files in the form of `DocumentFormat.OpenXml/src/GeneratedCode/Office*Schema.cs`. This update only needs to be run when there is a change to the binary files; otherwise, they will return the same result. These updated files are only used in the .NET Sandard implementation, while the binary files will continue to be used in the .NET 4.5 builds.
+
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 os: Visual Studio 2017
 
 environment:
-  image: Visual Studio 2017
+  image: Visual Studio 2017 Preview
   SignClientSecret:
     secure: 2QKIbnEaxM/df01+GLvTjVKdLL7RlwKmCR/APcWFRUUF2VQWBRQFQ1DP3gK49epL
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
-os: Visual Studio 2017
+os: Visual Studio 2017 Preview
 
 environment:
-  image: Visual Studio 2017
+  image: Visual Studio 2017 Preview
   SignClientSecret:
     secure: 2QKIbnEaxM/df01+GLvTjVKdLL7RlwKmCR/APcWFRUUF2VQWBRQFQ1DP3gK49epL
 
@@ -24,10 +24,4 @@ test_script:
   - vstest.console.exe /logger:appveyor DocumentFormat.OpenXml.Tests\bin\Release\net46\DocumentFormat.OpenXml.Tests.dll /Framework:Framework45
   - vstest.console.exe /logger:appveyor DocumentFormat.OpenXml.Tests\bin\Release\net452\DocumentFormat.OpenXml.Tests.dll /Framework:Framework45
 
-deploy:
-  provider: NuGet
-  server: https://dotnet.myget.org/F/open-xml-sdk/api/v2/package
-  api_key:
-    secure: +uagaLcg+y8G8ZBxlXm0E5VmTHeT030NeoyHZGU8V7MtIPc1+VUXru0mAPVh0KhK
-  on:
-    branch: [master, vNext, Office2016]
+


### PR DESCRIPTION
For net standard 2.0 builds, you have to use the preview image on appveyor. Until they update the normal image.

This builds and tests successfully on my CI at https://ci.appveyor.com/project/igitur/open-xml-sdk/build/2.7.0-vs2017-preview-image.151.build.5